### PR TITLE
Update - Replace DOM manipulation with Atomico render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "atomico-use-head",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "atomico-use-head",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.4.0",
-        "atomico": "^1.43.0",
+        "atomico": "1.45.1",
         "jest": "^27.4.7",
         "microbundle": "^0.14.2",
         "rimraf": "^3.0.2",
@@ -18,7 +17,7 @@
         "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "atomico": "^1.43.0"
+        "atomico": "^1.45.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2584,9 +2583,9 @@
       "dev": true
     },
     "node_modules/atomico": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/atomico/-/atomico-1.43.0.tgz",
-      "integrity": "sha512-q/7qP8O2UD0I/qNAlS9zT/K1feeB4Oh5jy1uVnBmFGoK/9h/GlZggw6o3wXI0WZNn5SlYR0CjGWKijU/LpdcYQ==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/atomico/-/atomico-1.45.1.tgz",
+      "integrity": "sha512-yaRcfhkcFPFVRkG+iPEQW1g4LhLqOf9sYOqN7ijQEe04Qh8j0ycw7R1PeGf/vu6SQg/Ix0rmjm+g0WB/NMGFUQ==",
       "dev": true
     },
     "node_modules/autoprefixer": {
@@ -10108,9 +10107,9 @@
       "dev": true
     },
     "atomico": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/atomico/-/atomico-1.43.0.tgz",
-      "integrity": "sha512-q/7qP8O2UD0I/qNAlS9zT/K1feeB4Oh5jy1uVnBmFGoK/9h/GlZggw6o3wXI0WZNn5SlYR0CjGWKijU/LpdcYQ==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/atomico/-/atomico-1.45.1.tgz",
+      "integrity": "sha512-yaRcfhkcFPFVRkG+iPEQW1g4LhLqOf9sYOqN7ijQEe04Qh8j0ycw7R1PeGf/vu6SQg/Ix0rmjm+g0WB/NMGFUQ==",
       "dev": true
     },
     "autoprefixer": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/keplersj/atomico-use-head#readme",
   "devDependencies": {
     "@types/jest": "^27.4.0",
-    "atomico": "^1.43.0",
+    "atomico": "1.45.1",
     "jest": "^27.4.7",
     "microbundle": "^0.14.2",
     "rimraf": "^3.0.2",
@@ -44,7 +44,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "atomico": "^1.43.0"
+    "atomico": "^1.45.1"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -59,7 +59,7 @@ Object {
     ],
     "style": Array [
       Object {
-        "innerText": "body {color: red}",
+        "children": "body {color: red}",
       },
     ],
     "title": "Test",
@@ -69,14 +69,16 @@ Object {
 
 exports[`useHead Hook hook, with initial state returns a result object when run 2`] = `
 <html
-  data-atomico-helmet="lang"
   lang="en"
 >
   <head>
+    Mark {}
     <title
       data-atomico-helmet="true"
     >
+      Mark {}
       Test
+      Mark {}
     </title>
     <meta
       content="Test Description"
@@ -96,17 +98,21 @@ exports[`useHead Hook hook, with initial state returns a result object when run 
     />
     <style
       data-atomico-helmet="true"
-    />
+    >
+      Mark {}
+      body {color: red}
+      Mark {}
+    </style>
     <script
       as="script"
       data-atomico-helmet="true"
       href="/framework.js"
       rel="preload"
     />
+    Mark {}
   </head>
   <body
     class="root"
-    data-atomico-helmet="class"
   >
     <div />
   </body>
@@ -114,9 +120,16 @@ exports[`useHead Hook hook, with initial state returns a result object when run 
 `;
 
 exports[`useHead Hook hook, with initial state returns a result object when run 3`] = `
-<html>
-  <head />
-  <body>
+<html
+  lang=""
+>
+  <head>
+    Mark {}
+    Mark {}
+  </head>
+  <body
+    class=""
+  >
     <div />
   </body>
 </html>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,7 +26,7 @@ describe("useHead Hook", () => {
       const hooks = createHooks(jest.fn(), host);
 
       const { useHead } = await import("./index");
-      const head = hooks.load(() => useHead());
+      const head = hooks.load(() => useHead({}));
 
       expect(head).toMatchSnapshot();
 
@@ -64,7 +64,7 @@ describe("useHead Hook", () => {
           },
           style: [
             {
-              innerText: "body {color: red}",
+              children: "body {color: red}",
             },
           ],
           script: [


### PR DESCRIPTION
Hi, I have used useHead and notice that the state is fixed and it cannot be updated.
I have generated modifications to achieve that when modifying the first argument to useHead the associated DOM is updated.

1. I have used the Atomico render to modify the DOM, this reduces the code in general code.
2. I have modified the test to accept the new changes.

> Thanks to its library I was able to notice that there was an error in the Atomico types for useRender and h when trying to make these changes, so I have updated Atomico to correct it.

It is not necessary to accept this PR if the commented objectives do not agree with that of your library, I hope the changes are to your liking, by the way I apologize for the colossal commit



